### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add `less-watch-compiler.config.json` as follows in your project folder
 
 ```
 {
-    "allowedExtensions":["less"],
+    "allowedExtensions":[".less"],
     "defaults": {
         "watchFolder": "tests/less",
         "outputFolder": "tests/css"


### PR DESCRIPTION
Typo in Example #2 allowedExtensions array that was causing watcher to seemingly hang at Watching directory for file changes.
Fix for issue #9.
